### PR TITLE
Api provides ability to re vote on a poll

### DIFF
--- a/app/controllers/api/polls_controller.rb
+++ b/app/controllers/api/polls_controller.rb
@@ -36,16 +36,12 @@ class Api::PollsController < ApplicationController
     params.require(:poll).permit(:title, :description, :tasks, points: [], team: [], votes: {})
   end
 
-  def user_email
-    current_user.uid
-  end
-
   def team_update
     poll = Poll.find(params[:id])
-    if poll.team.include?(current_user.uid)
+    if poll.team.include?(current_user.name)
       render json: { message: 'You already joined this poll' }, status: :unprocessable_entity
     else
-      poll.team.push(current_user.uid)
+      poll.team.push(current_user.name)
       poll.save!
       render json: { message: 'successfully joined', team: poll.team }, status: :ok
     end

--- a/app/controllers/api/polls_controller.rb
+++ b/app/controllers/api/polls_controller.rb
@@ -54,7 +54,11 @@ class Api::PollsController < ApplicationController
   def points_update
     poll = Poll.find(params[:id])
     user = current_user.uid
-    if poll.persisted?
+    if poll.votes.include?(user)
+      poll.votes.except!(user)
+      poll.save!
+      render json: { message: 'successfully un-voted', votes: poll.votes, points: poll.points }, status: :ok
+    elsif poll.persisted?
       poll.points.push(params['poll']['points'])
       poll.votes[user] = params['poll']['points']
       poll.save!

--- a/app/controllers/api/polls_controller.rb
+++ b/app/controllers/api/polls_controller.rb
@@ -61,7 +61,7 @@ class Api::PollsController < ApplicationController
       poll.save!
       render json: { message: 'successfully voted', votes: poll.votes, points: poll.points }, status: :ok
     elsif poll.votes.include?(user)
-      poll.points.delete(params['poll']['points'])
+      poll.points.delete(poll.votes[user])
       poll.votes.except!(user)
       poll.save!
       render json: { message: 'successfully un-voted', votes: poll.votes, points: poll.points }, status: :ok

--- a/app/controllers/api/polls_controller.rb
+++ b/app/controllers/api/polls_controller.rb
@@ -53,12 +53,12 @@ class Api::PollsController < ApplicationController
 
   def points_update
     poll = Poll.find(params[:id])
+    user = current_user.uid
     if poll.persisted?
       poll.points.push(params['poll']['points'])
-      poll.votes = params['poll']['votes']
-      poll.votes.merge!(current_user.uid => params['poll']['points'])
+      poll.votes[user] = params['poll']['points']
       poll.save!
-      render json: { message: 'successfully voted', votes: poll.votes, points: poll.points}, status: :ok
+      render json: { message: 'successfully voted', votes: poll.votes, points: poll.points }, status: :ok
     else
       render status: :unauthorized
     end

--- a/app/controllers/api/polls_controller.rb
+++ b/app/controllers/api/polls_controller.rb
@@ -54,15 +54,17 @@ class Api::PollsController < ApplicationController
   def points_update
     poll = Poll.find(params[:id])
     user = current_user.uid
-    if poll.votes.include?(user)
-      poll.votes.except!(user)
-      poll.save!
-      render json: { message: 'successfully un-voted', votes: poll.votes, points: poll.points }, status: :ok
-    elsif poll.persisted?
+    poll.votes = ({}) unless poll.votes
+    if !poll.votes.include?(user)
       poll.points.push(params['poll']['points'])
       poll.votes[user] = params['poll']['points']
       poll.save!
       render json: { message: 'successfully voted', votes: poll.votes, points: poll.points }, status: :ok
+    elsif poll.votes.include?(user)
+      poll.points.delete(params['poll']['points'])
+      poll.votes.except!(user)
+      poll.save!
+      render json: { message: 'successfully un-voted', votes: poll.votes, points: poll.points }, status: :ok
     else
       render status: :unauthorized
     end

--- a/app/controllers/api/polls_controller.rb
+++ b/app/controllers/api/polls_controller.rb
@@ -51,7 +51,9 @@ class Api::PollsController < ApplicationController
     poll = Poll.find(params[:id])
     user = current_user.uid
     poll.votes = ({}) unless poll.votes
-    if !poll.votes.include?(user)
+    if params['poll']['points'].nil?
+      render json: { error_message: 'You need to pick a value to vote' }, status: :unprocessable_entity
+    elsif !poll.votes.include?(user)
       poll.points.push(params['poll']['points'])
       poll.votes[user] = params['poll']['points']
       poll.save!
@@ -62,7 +64,7 @@ class Api::PollsController < ApplicationController
       poll.save!
       render json: { message: 'successfully un-voted', votes: poll.votes, points: poll.points }, status: :ok
     else
-      render status: :unauthorized
+      render json: { error_message: 'Unauthorized, You need to sign in before you can proceed' }, status: :unauthorized
     end
   end
 end

--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     tasks { "MyTasks" }
     points { [2] }
     team { ["teamMember1@epidemic.com", "teamMember2@epidemic.com"]}
-    votes {{  }}
+    votes {{ "teamMember1@epidemic.com": 0, "secondmember@mail.com": 2 }}
     association :user, factory: :user
   end
 end

--- a/spec/factories/polls.rb
+++ b/spec/factories/polls.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     tasks { "MyTasks" }
     points { [2] }
     team { ["teamMember1@epidemic.com", "teamMember2@epidemic.com"]}
-    votes {{ "teamMember1@epidemic.com": 0, "secondmember@mail.com": 2 }}
+    votes {{ "votingUser1@mail.com": 0, "votingUser2@mail.com": 2 }}
     association :user, factory: :user
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     email { "user#{rand(0..999)}@epidemic.com"  }
     password { 'password' }
     password_confirmation { 'password' }
-    name { 'user' }
+    name { "user#{rand(0..999)}" }
   end
 end

--- a/spec/request/api/polls/update_spec.rb
+++ b/spec/request/api/polls/update_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
 
     it 'updates an poll with team' do
       poll = Poll.last
-      expect(poll.team).to eq ['teamMember1@epidemic.com', 'teamMember2@epidemic.com', user.uid]
+      expect(poll.team).to eq ['teamMember1@epidemic.com', 'teamMember2@epidemic.com', user.name]
     end
   end
 

--- a/spec/request/api/polls/update_spec.rb
+++ b/spec/request/api/polls/update_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
 
     it 'updates an poll with votes' do
       poll = Poll.last
-      expect(poll.votes).to eq "#{user.uid}"=>"#{3}"
+      expect(poll.votes).to eq :"secondmember@mail.com"=>2, :"teamMember1@epidemic.com"=>0,"#{user.uid}"=>"#{3}"
     end
   end
 

--- a/spec/request/api/polls/update_spec.rb
+++ b/spec/request/api/polls/update_spec.rb
@@ -5,96 +5,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
   let(:headers) { { HTTP_ACCEPT: 'application/json' }.merge!(credentials) }
   let!(:user1) { create(:user, email: 're-vote_user@mail.com') }
 
-  
-  describe 'user successfully un-vote on a poll' do
-    before do
-      put "/api/polls/#{poll.id}",
-          params: {
-            poll: {
-              points: 3,
-              votes: { "#{user.uid}": "#{poll.points}"}
-            }
-          }, headers: headers
-    end
-    before do
-      put "/api/polls/#{poll.id}",
-          params: {
-            poll: {
-              points: 3,
-              votes: { "#{user.uid}": "#{poll.points}"}
-            }
-          }, headers: headers
-    end
-
-    it 'responds with ok status' do
-      expect(response).to have_http_status :ok
-    end
-
-    it 'returns success message' do
-      expect(response_json['message']).to eq 'successfully un-voted'
-    end
-
-    it 'updates an poll with votes' do
-      poll = Poll.last
-      expect(poll.votes).to eq :"votingUser1@mail.com"=>0, :"votingUser2@mail.com"=>2
-    end
-  end
-  
-  
-  
-  
-  
-  
-  
-  
-  describe 'user successfully vote on a poll' do
-    before do
-      put "/api/polls/#{poll.id}",
-          params: {
-            poll: {
-              points: 3,
-              votes: { "#{user.uid}": "#{poll.points}"}
-            }
-          }, headers: headers
-    end
-
-    it 'responds with ok status' do
-      expect(response).to have_http_status :ok
-    end
-
-    it 'returns success message' do
-      expect(response_json['message']).to eq 'successfully voted'
-    end
-
-    it 'updates an poll with points' do
-      poll = Poll.last
-      expect(poll.points).to eq [2, 3]
-    end
-
-    it 'updates an poll with votes' do
-      poll = Poll.last
-      expect(poll.votes).to eq :"votingUser2@mail.com"=>2, :"votingUser1@mail.com"=>0,"#{user.uid}"=>"#{3}"
-    end
-  end
-
-  describe 'unsuccessfully join - not authorized' do
-    before do
-      put "/api/polls/#{poll.id}",
-          params: {
-            poll: {
-              points: 3,
-              votes: { "#{user.uid}": "#{poll.points}"}
-            }
-          }
-    end
-
-    it 'responds with unauthorized status' do
-      expect(response).to have_http_status :unauthorized
-    end
-  end
-
-
-  describe 'user successfully apply to join a poll' do
+  describe 'user successfully join a poll' do
     before do
       put "/api/polls/#{poll.id}",
           params: {
@@ -139,6 +50,84 @@ RSpec.describe 'PUT /api/polls', type: :request do
       expect(response_json['message']).to eq 'You already joined this poll'
     end
   end
+
+  describe 'user successfully vote on a poll' do
+    before do
+      put "/api/polls/#{poll.id}",
+          params: {
+            poll: {
+              points: 3,
+              votes: { "#{user.uid}": poll.points.to_s }
+            }
+          }, headers: headers
+    end
+
+    it 'responds with ok status' do
+      expect(response).to have_http_status :ok
+    end
+
+    it 'returns success message' do
+      expect(response_json['message']).to eq 'successfully voted'
+    end
+
+    it 'updates an poll with points' do
+      poll = Poll.last
+      expect(poll.points).to eq [2, 3]
+    end
+
+    it 'updates an poll with votes' do
+      poll = Poll.last
+      expect(poll.votes).to eq :"votingUser2@mail.com" => 2, :"votingUser1@mail.com" => 0, user.uid.to_s => '3'
+    end
+  end
+
+  describe 'unsuccessfully vote - not authorized' do
+    before do
+      put "/api/polls/#{poll.id}",
+          params: {
+            poll: {
+              points: 3,
+              votes: { "#{user.uid}": poll.points.to_s}
+            }
+          }
+    end
+
+    it 'responds with unauthorized status' do
+      expect(response).to have_http_status :unauthorized
+    end
+  end
+
+  describe 'user successfully un-vote on a poll' do
+    before do
+      put "/api/polls/#{poll.id}",
+          params: {
+            poll: {
+              points: 3,
+              votes: { "#{user.uid}": poll.points.to_s}
+            }
+          }, headers: headers
+    end
+    before do
+      put "/api/polls/#{poll.id}",
+          params: {
+            poll: {
+              points: 3,
+              votes: { "#{user.uid}": poll.points.to_s}
+            }
+          }, headers: headers
+    end
+
+    it 'responds with ok status' do
+      expect(response).to have_http_status :ok
+    end
+
+    it 'returns success message' do
+      expect(response_json['message']).to eq 'successfully un-voted'
+    end
+
+    it 'updates an poll with votes' do
+      poll = Poll.last
+      expect(poll.votes).to eq "votingUser1@mail.com": 0, "votingUser2@mail.com": 2
+    end
+  end
 end
-
-

--- a/spec/request/api/polls/update_spec.rb
+++ b/spec/request/api/polls/update_spec.rb
@@ -3,7 +3,50 @@ RSpec.describe 'PUT /api/polls', type: :request do
   let(:user) { create(:user) }
   let(:credentials) { user.create_new_auth_token }
   let(:headers) { { HTTP_ACCEPT: 'application/json' }.merge!(credentials) }
+  let!(:user1) { create(:user, email: 're-vote_user@mail.com') }
 
+  
+  describe 'user successfully un-vote on a poll' do
+    before do
+      put "/api/polls/#{poll.id}",
+          params: {
+            poll: {
+              points: 3,
+              votes: { "#{user.uid}": "#{poll.points}"}
+            }
+          }, headers: headers
+    end
+    before do
+      put "/api/polls/#{poll.id}",
+          params: {
+            poll: {
+              points: 3,
+              votes: { "#{user.uid}": "#{poll.points}"}
+            }
+          }, headers: headers
+    end
+
+    it 'responds with ok status' do
+      expect(response).to have_http_status :ok
+    end
+
+    it 'returns success message' do
+      expect(response_json['message']).to eq 'successfully un-voted'
+    end
+
+    it 'updates an poll with votes' do
+      poll = Poll.last
+      expect(poll.votes).to eq :"votingUser1@mail.com"=>0, :"votingUser2@mail.com"=>2
+    end
+  end
+  
+  
+  
+  
+  
+  
+  
+  
   describe 'user successfully vote on a poll' do
     before do
       put "/api/polls/#{poll.id}",
@@ -30,7 +73,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
 
     it 'updates an poll with votes' do
       poll = Poll.last
-      expect(poll.votes).to eq :"secondmember@mail.com"=>2, :"teamMember1@epidemic.com"=>0,"#{user.uid}"=>"#{3}"
+      expect(poll.votes).to eq :"votingUser2@mail.com"=>2, :"votingUser1@mail.com"=>0,"#{user.uid}"=>"#{3}"
     end
   end
 
@@ -48,10 +91,6 @@ RSpec.describe 'PUT /api/polls', type: :request do
     it 'responds with unauthorized status' do
       expect(response).to have_http_status :unauthorized
     end
-
-  
-
- 
   end
 
 
@@ -101,3 +140,5 @@ RSpec.describe 'PUT /api/polls', type: :request do
     end
   end
 end
+
+

--- a/spec/request/api/polls/update_spec.rb
+++ b/spec/request/api/polls/update_spec.rb
@@ -87,13 +87,29 @@ RSpec.describe 'PUT /api/polls', type: :request do
           params: {
             poll: {
               points: 3,
-              votes: { "#{user.uid}": poll.points.to_s}
+              votes: { "#{user.uid}": poll.points.to_s }
             }
           }
     end
 
     it 'responds with unauthorized status' do
       expect(response).to have_http_status :unauthorized
+    end
+  end
+
+  describe 'unsuccessfully vote - points are missing' do
+    before do
+      put "/api/polls/#{poll.id}",
+          params: {
+            poll: {
+              points: nil,
+              votes: { "#{user.uid}": poll.points.to_s}
+            }
+          }, headers: headers
+    end
+
+    it 'responds with unauthorized status' do
+      expect(response).to have_http_status :unprocessable_entity
     end
   end
 


### PR DESCRIPTION
[PT](https://www.pivotaltracker.com/story/show/176221461)
## This PR contains:
- spec: update_spec, 'user successfully un-vote on a poll' 
- polls controller: deletes points from points attribute, delete user and corresponding points from votes hash when request contains current_user.




