### PR TITLE
Api provides ability to close poll

### DIFF
--- a/app/controllers/api/polls_controller.rb
+++ b/app/controllers/api/polls_controller.rb
@@ -89,8 +89,12 @@ class Api::PollsController < ApplicationController
 
   def result_update
     poll = Poll.find(params[:id])
+    if poll.result.nil?
     poll.update!(update_params)
     poll.update!({state: "closed"})
     render json: { message: 'result successfully assigned', state: poll.state, result: poll.result }, status: :ok
+    else
+      render json: { message: 'result is already assigned' }, status: :unprocessable_entity
+    end
   end
 end

--- a/app/controllers/api/polls_controller.rb
+++ b/app/controllers/api/polls_controller.rb
@@ -29,6 +29,8 @@ class Api::PollsController < ApplicationController
       points_update
     elsif params['poll']['state']
       state_update
+    elsif params['poll']['result']
+      result_update
     end
   end
 
@@ -78,11 +80,17 @@ class Api::PollsController < ApplicationController
   def state_update
     poll = Poll.find(params[:id])
     poll.update!(update_params)
-
     render json: { message: 'Voting succesfully closed', state: poll.state, votes: poll.votes }, status: :ok
   end
 
   def update_params
-    params.require(:poll).permit(:state)
+    params.require(:poll).permit(:state, :result)
+  end
+
+  def result_update
+    poll = Poll.find(params[:id])
+    poll.update!(update_params)
+    poll.update!({state: "closed"})
+    render json: { message: 'result successfully assigned', state: poll.state, result: poll.result }, status: :ok
   end
 end

--- a/app/controllers/api/polls_controller.rb
+++ b/app/controllers/api/polls_controller.rb
@@ -9,6 +9,7 @@ class Api::PollsController < ApplicationController
   def create
     poll = current_user.polls.create(poll_params)
     if poll.persisted? && attach_image(poll) || poll.persisted?
+      poll.update!({state: "ongoing"})
       render json: { message: 'successfully saved', id: poll.id }
     else
       error_message(poll.errors)

--- a/app/serializers/polls_show_serializer.rb
+++ b/app/serializers/polls_show_serializer.rb
@@ -1,5 +1,5 @@
 class PollsShowSerializer < ActiveModel::Serializer
-  attributes :id, :title, :description, :tasks, :points, :team, :votes, :image, :state
+  attributes :id, :title, :description, :tasks, :points, :team, :votes, :image, :state, :result
 
   def image
     return nil unless object.image.attached?

--- a/db/migrate/20210107171707_add_result_to_poll.rb
+++ b/db/migrate/20210107171707_add_result_to_poll.rb
@@ -1,0 +1,5 @@
+class AddResultToPoll < ActiveRecord::Migration[6.0]
+  def change
+    add_column :polls, :result, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_07_102145) do
+ActiveRecord::Schema.define(version: 2021_01_07_171707) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 2021_01_07_102145) do
     t.string "team", default: [], array: true
     t.text "votes"
     t.integer "state", default: 0
+    t.integer "result"
     t.index ["user_id"], name: "index_polls_on_user_id"
   end
 

--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Poll, type: :model do
     it { is_expected.to have_db_column :team }
     it { is_expected.to have_db_column :votes }
     it { is_expected.to have_db_column :state }
+    it { is_expected.to have_db_column :result }
   end
 
   describe "Validations" do

--- a/spec/request/api/polls/create_spec.rb
+++ b/spec/request/api/polls/create_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe 'POST /api/polls', type: :request do
       expect(poll.description).to include 'As an API'
       expect(poll.tasks).to eq 'index action, routes to the action, polls model: title, description, polls Index in serializer'
       expect(poll.points).to eq [nil]
+      expect(poll.state).to eq 'ongoing'
     end
 
     it 'poll is expected to have an image attached' do

--- a/spec/request/api/polls/update_spec.rb
+++ b/spec/request/api/polls/update_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
   let(:headers) { { HTTP_ACCEPT: 'application/json' }.merge!(credentials) }
   let!(:user1) { create(:user, email: 're-vote_user@mail.com') }
 
-  describe 'user successfully join a poll' do
+  xdescribe 'user successfully join a poll' do
     before do
       put "/api/polls/#{poll.id}",
           params: {
@@ -29,7 +29,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
     end
   end
 
-  describe 'unsuccessfully join - user already joined a poll' do
+  xdescribe 'unsuccessfully join - user already joined a poll' do
     before do
       put "/api/polls/#{poll.id}",
           params: {
@@ -51,7 +51,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
     end
   end
 
-  describe 'user successfully vote on a poll' do
+  xdescribe 'user successfully vote on a poll' do
     before do
       put "/api/polls/#{poll.id}",
           params: {
@@ -81,7 +81,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
     end
   end
 
-  describe 'unsuccessfully vote - not authorized' do
+  xdescribe 'unsuccessfully vote - not authorized' do
     before do
       put "/api/polls/#{poll.id}",
           params: {
@@ -97,7 +97,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
     end
   end
 
-  describe 'unsuccessfully vote - points are missing' do
+  xdescribe 'unsuccessfully vote - points are missing' do
     before do
       put "/api/polls/#{poll.id}",
           params: {
@@ -113,7 +113,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
     end
   end
 
-  describe 'user successfully un-vote on a poll' do
+  xdescribe 'user successfully un-vote on a poll' do
     before do
       put "/api/polls/#{poll.id}",
           params: {
@@ -147,7 +147,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
     end
   end
 
-  describe 'user successfully close voting by changing poll state from ongoing to pending' do
+  xdescribe 'user successfully close voting by changing poll state from ongoing to pending' do
     before do
       put "/api/polls/#{poll.id}",
           params: {
@@ -172,7 +172,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
     end
   end
 
-  describe 'unsuccessfully close voting - not authorized' do
+  xdescribe 'unsuccessfully close voting - not authorized' do
     before do
       put "/api/polls/#{poll.id}",
           params: {

--- a/spec/request/api/polls/update_spec.rb
+++ b/spec/request/api/polls/update_spec.rb
@@ -187,4 +187,34 @@ RSpec.describe 'PUT /api/polls', type: :request do
       expect(response).to have_http_status :unauthorized
     end
   end
+
+  describe 'user successfully close poll by assigning a result value' do
+    before do
+      put "/api/polls/#{poll.id}",
+          params: {
+            poll: {
+              result: 2
+
+            }
+          }, headers: headers
+    end
+
+    it 'responds with ok status' do
+      expect(response).to have_http_status :ok
+    end
+
+    it 'returns success message' do
+      expect(response_json['message']).to eq 'result successfully assigned'
+    end
+
+    it 'returns polls result' do
+      poll = Poll.last
+      expect(poll.result).to eq 2
+    end
+
+    it 'returns updated poll state' do
+      poll = Poll.last
+      expect(poll.state).to eq 'closed'
+    end
+end
 end

--- a/spec/request/api/polls/update_spec.rb
+++ b/spec/request/api/polls/update_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
   let(:headers) { { HTTP_ACCEPT: 'application/json' }.merge!(credentials) }
   let!(:user1) { create(:user, email: 're-vote_user@mail.com') }
 
-  xdescribe 'user successfully join a poll' do
+  describe 'user successfully join a poll' do
     before do
       put "/api/polls/#{poll.id}",
           params: {
@@ -29,7 +29,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
     end
   end
 
-  xdescribe 'unsuccessfully join - user already joined a poll' do
+  describe 'unsuccessfully join - user already joined a poll' do
     before do
       put "/api/polls/#{poll.id}",
           params: {
@@ -51,7 +51,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
     end
   end
 
-  xdescribe 'user successfully vote on a poll' do
+  describe 'user successfully vote on a poll' do
     before do
       put "/api/polls/#{poll.id}",
           params: {
@@ -81,7 +81,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
     end
   end
 
-  xdescribe 'unsuccessfully vote - not authorized' do
+  describe 'unsuccessfully vote - not authorized' do
     before do
       put "/api/polls/#{poll.id}",
           params: {
@@ -97,7 +97,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
     end
   end
 
-  xdescribe 'unsuccessfully vote - points are missing' do
+  describe 'unsuccessfully vote - points are missing' do
     before do
       put "/api/polls/#{poll.id}",
           params: {
@@ -113,7 +113,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
     end
   end
 
-  xdescribe 'user successfully un-vote on a poll' do
+  describe 'user successfully un-vote on a poll' do
     before do
       put "/api/polls/#{poll.id}",
           params: {
@@ -128,7 +128,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
           params: {
             poll: {
               points: 3,
-              votes: { "#{user.name}": poll.points.to_s}
+              votes: { "#{user.name}": poll.points.to_s }
             }
           }, headers: headers
     end
@@ -147,7 +147,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
     end
   end
 
-  xdescribe 'user successfully close voting by changing poll state from ongoing to pending' do
+  describe 'user successfully close voting by changing poll state from ongoing to pending' do
     before do
       put "/api/polls/#{poll.id}",
           params: {
@@ -172,7 +172,7 @@ RSpec.describe 'PUT /api/polls', type: :request do
     end
   end
 
-  xdescribe 'unsuccessfully close voting - not authorized' do
+  describe 'unsuccessfully close voting - not authorized' do
     before do
       put "/api/polls/#{poll.id}",
           params: {
@@ -216,5 +216,31 @@ RSpec.describe 'PUT /api/polls', type: :request do
       poll = Poll.last
       expect(poll.state).to eq 'closed'
     end
-end
+  end
+
+  describe 'unsuccessfully close - result value is already assigned' do
+    before do
+      put "/api/polls/#{poll.id}",
+          params: {
+            poll: {
+              result: 2
+            }
+          }, headers: headers
+    end
+    before do
+      put "/api/polls/#{poll.id}",
+          params: {
+            poll: {
+              result: 2
+            }
+          }, headers: headers
+    end
+    it 'responds with unprocessable_entity' do
+      expect(response).to have_http_status :unprocessable_entity
+    end
+
+    it 'returns error message' do
+      expect(response_json['message']).to eq 'result is already assigned'
+    end
+  end
 end


### PR DESCRIPTION
[PT](https://www.pivotaltracker.com/story/show/176399315)

## This PR contains
- spec: polls/update_spec.rb
describe block 'user successfully close poll by assigning a result value' & ' unsuccessfully close - result value is already assigned'
- migration: adds result attribute to poll
- result_update in polls controller